### PR TITLE
Refactor onlyOwner checks from `Blockchain.txOrigin` to `Blockchain.msgSender` for accurate ownership verification

### DIFF
--- a/runtime/contracts/DeployableOP_20.ts
+++ b/runtime/contracts/DeployableOP_20.ts
@@ -1,20 +1,20 @@
-import { IOP_20 } from './interfaces/IOP_20';
 import { u256 } from 'as-bignum/assembly';
-import { Address } from '../types/Address';
 import { BytesWriter } from '../buffer/BytesWriter';
-import { Calldata } from '../universal/ABIRegistry';
-import { OP_NET } from './OP_NET';
+import { Blockchain } from '../env';
+import { ApproveEvent, BurnEvent, MintEvent, TransferEvent } from '../events/predefined';
+import { encodeSelector, Selector } from '../math/abi';
 import { AddressMemoryMap } from '../memory/AddressMemoryMap';
+import { MemorySlotData } from '../memory/MemorySlot';
+import { MultiAddressMemoryMap } from '../memory/MultiAddressMemoryMap';
+import { StoredString } from '../storage/StoredString';
+import { StoredU256 } from '../storage/StoredU256';
+import { Address } from '../types/Address';
 import { Revert } from '../types/Revert';
 import { SafeMath } from '../types/SafeMath';
-import { Blockchain } from '../env';
-import { MemorySlotData } from '../memory/MemorySlot';
-import { encodeSelector, Selector } from '../math/abi';
-import { MultiAddressMemoryMap } from '../memory/MultiAddressMemoryMap';
-import { StoredU256 } from '../storage/StoredU256';
-import { ApproveEvent, BurnEvent, MintEvent, TransferEvent } from '../events/predefined';
-import { StoredString } from '../storage/StoredString';
+import { Calldata } from '../universal/ABIRegistry';
+import { IOP_20 } from './interfaces/IOP_20';
 import { OP20InitParameters } from './interfaces/OP20InitParameters';
+import { OP_NET } from './OP_NET';
 
 const maxSupplyPointer: u16 = Blockchain.nextPointer;
 const decimalsPointer: u16 = Blockchain.nextPointer;
@@ -94,7 +94,7 @@ export abstract class DeployableOP_20 extends OP_NET implements IOP_20 {
             throw new Revert('Already initialized');
         }
 
-        if (!skipOwnerVerification) this.onlyOwner(Blockchain.txOrigin);
+        if (!skipOwnerVerification) this.onlyOwner(Blockchain.msgSender);
 
         if (params.decimals > 32) {
             throw new Revert('Decimals can not be more than 32');
@@ -259,7 +259,7 @@ export abstract class DeployableOP_20 extends OP_NET implements IOP_20 {
             throw new Revert(`No tokens`);
         }
 
-        if (onlyOwner) this.onlyOwner(Blockchain.txOrigin); // only indexers can burn tokens
+        if (onlyOwner) this.onlyOwner(Blockchain.msgSender); // only indexers can burn tokens
 
         if (this._totalSupply.value < value) throw new Revert(`Insufficient total supply.`);
         if (!this.balanceOfMap.has(Blockchain.msgSender)) throw new Revert('No balance');
@@ -278,7 +278,7 @@ export abstract class DeployableOP_20 extends OP_NET implements IOP_20 {
     }
 
     protected _mint(to: Address, value: u256, onlyOwner: boolean = true): boolean {
-        if (onlyOwner) this.onlyOwner(Blockchain.txOrigin);
+        if (onlyOwner) this.onlyOwner(Blockchain.msgSender);
 
         if (!this.balanceOfMap.has(to)) {
             this.balanceOfMap.set(to, value);

--- a/runtime/contracts/DeployableOP_20.ts
+++ b/runtime/contracts/DeployableOP_20.ts
@@ -259,7 +259,7 @@ export abstract class DeployableOP_20 extends OP_NET implements IOP_20 {
             throw new Revert(`No tokens`);
         }
 
-        if (onlyOwner) this.onlyOwner(Blockchain.msgSender); // only indexers can burn tokens
+        if (onlyOwner) this.onlyOwner(Blockchain.msgSender);
 
         if (this._totalSupply.value < value) throw new Revert(`Insufficient total supply.`);
         if (!this.balanceOfMap.has(Blockchain.msgSender)) throw new Revert('No balance');


### PR DESCRIPTION
### Description:
- Updated the `onlyOwner` checks to use `Blockchain.msgSender` instead of `Blockchain.txOrigin`. This ensures that the ownership validation is based on the **direct caller** of the contract, as it should be, rather than the original transaction initiator.
  
- This change aligns the ownership checks with standard practices in Solidity, where `msgSender` is used to validate the caller in `onlyOwner` modifiers.

#### Solidity Example:

In Solidity, the standard `onlyOwner` modifier uses `msgSender` to check the caller, as shown below:

```solidity
modifier onlyOwner() {
    require(_owner == _msgSender(), "Ownable: caller is not the owner");
    _;
}
```

This ensures that only the direct caller, not the original initiator, can perform privileged actions. The update to use `Blockchain.msgSender` follows this logic and strengthens contract security.