### PR TITLE
Fix: Remove public mint() function from OP_NET token contract

### DIFF
--- a/runtime/contracts/DeployableOP_20.ts
+++ b/runtime/contracts/DeployableOP_20.ts
@@ -12,10 +12,10 @@ import { Address } from '../types/Address';
 import { Revert } from '../types/Revert';
 import { SafeMath } from '../types/SafeMath';
 
+import { Calldata } from '../types';
 import { IOP_20 } from './interfaces/IOP_20';
 import { OP20InitParameters } from './interfaces/OP20InitParameters';
 import { OP_NET } from './OP_NET';
-import { Calldata } from '../types';
 
 const maxSupplyPointer: u16 = Blockchain.nextPointer;
 const decimalsPointer: u16 = Blockchain.nextPointer;
@@ -150,15 +150,6 @@ export abstract class DeployableOP_20 extends OP_NET implements IOP_20 {
         return response;
     }
 
-    public mint(callData: Calldata): BytesWriter {
-        const response = new BytesWriter(1);
-        const resp = this._mint(callData.readAddress(), callData.readU256());
-
-        response.writeBoolean(resp);
-
-        return response;
-    }
-
     public transfer(callData: Calldata): BytesWriter {
         const response = new BytesWriter(1);
         const resp = this._transfer(callData.readAddress(), callData.readU256());
@@ -213,8 +204,6 @@ export abstract class DeployableOP_20 extends OP_NET implements IOP_20 {
                 return this.balanceOf(calldata);
             case encodeSelector('burn'):
                 return this.burn(calldata);
-            case encodeSelector('mint'):
-                return this.mint(calldata);
             case encodeSelector('transfer'):
                 return this.transfer(calldata);
             case encodeSelector('transferFrom'):

--- a/runtime/contracts/interfaces/IOP_20.ts
+++ b/runtime/contracts/interfaces/IOP_20.ts
@@ -16,6 +16,4 @@ export interface IOP_20 {
     allowance(callData: Calldata): BytesWriter;
 
     burn(callData: Calldata): BytesWriter;
-
-    mint(callData: Calldata): BytesWriter;
 }


### PR DESCRIPTION
### Summary
This pull request removes the `mint()` function that was publicly accessible in the `btc-runtime`. According to the ERC-20 token standard, the `mint()` function should never be publicly available as it poses a security risk by allowing anyone to mint new tokens.

### Changes:
- Removed the public `mint()` function from the OP_NET token contract to align with OP-20 standards.
- Ensured that the token can only be minted through internal logic and authorized mechanisms like an owner-controlled `airdrop()` function.

### Reason:
- OP-20 tokens should not have a public `mint()` function to prevent unauthorized token creation and inflation.
- This update secures the token contract and brings it in line with best practices for token development on the OP_NET metaprotocol.