### PR TITLE
Fix issue due to StoredBoolean while build

### DIFF
--- a/runtime/storage/StoredBoolean.ts
+++ b/runtime/storage/StoredBoolean.ts
@@ -9,7 +9,7 @@ export class StoredBoolean {
         public pointer: u16,
         private defaultValue: bool,
     ) {
-        this.u256Pointer = u256.from(this.pointer);
+        this.u256Pointer = u256.from(pointer);
     }
 
     private _value: u256 = u256.Zero;


### PR DESCRIPTION
Fix: Property '~lib/@btc-vision/btc-runtime/runtime/storage/StoredBoolean/StoredBoolean#u256Pointer' has no initializer and is not assigned in the constructor before 'this' is used or returned.