### PR TITLE
Fix `writeAddressArray` implicit cast

### DIFF
--- a/runtime/buffer/BytesWriter.ts
+++ b/runtime/buffer/BytesWriter.ts
@@ -49,7 +49,7 @@ export class BytesWriter {
     public writeAddressArray(value: Address[]): void {
         if (value.length > 65535) throw new Revert('Array size is too large');
 
-        this.writeU16(value.length);
+        this.writeU16(u16(value.length));
 
         for (let i: i32 = 0; i < value.length; i++) {
             this.writeAddress(value[i]);


### PR DESCRIPTION
Please change base / reclassify as necessary.

`writeAddressArray` fails to build with `asc` due to the use of `writeU16` for the length without casting to `u16` explicitly. 